### PR TITLE
Fix triss threading and init logic

### DIFF
--- a/Triss.py
+++ b/Triss.py
@@ -2,11 +2,8 @@
 class Triss(object):
     prize = -1
 
-    def __init__(self, newPrize):
-        self.prize = newPrize
-
-    def __init__(self):
-        self.prize = -1
+    def __init__(self, prize=-1):
+        self.prize = prize
 
     def setPrize(self, newPrize):
         self.prize = newPrize

--- a/TrissSimulator.py
+++ b/TrissSimulator.py
@@ -166,15 +166,18 @@ def generate_ticket_list():
     # Length of each interval
     part_lengths = int(end_index / number_of_threads)
 
+    threads = []
+
     for intervalNumber in range(start_index, number_of_threads):
         temp_start_interval = part_lengths * intervalNumber
         temp_end_interval = part_lengths + (part_lengths * intervalNumber)
 
         thread = Thread(target=createTrissList, args=(temp_start_interval, temp_end_interval))
         thread.start()
+        threads.append(thread)
 
     # Wait for all threads
-    for intervalNumber in range(0, number_of_threads):
+    for thread in threads:
         thread.join()
     #  ------ Threading ------
 


### PR DESCRIPTION
## Summary
- fix double `__init__` in `Triss`
- track created threads so we correctly wait for all of them

## Testing
- `python3 -m py_compile Triss.py TrissSimulator.py`

------
https://chatgpt.com/codex/tasks/task_e_683febd9fd38833090536e8a58dae7e4